### PR TITLE
Use render props for trigger and tooltip

### DIFF
--- a/src/TooltipTrigger.js
+++ b/src/TooltipTrigger.js
@@ -149,13 +149,14 @@ export default class TooltipTrigger extends PureComponent {
     this._clearScheduled();
   }
 
-  getTriggerProps = (props = {}) => {
+  getTriggerProps = ref => (props = {}) => {
     const isClickTriggered = this.props.trigger === 'click';
     const isHoverTriggered = this.props.trigger === 'hover';
     const isRightClickTriggered = this.props.trigger === 'right-click';
 
     return {
       ...props,
+      ref,
       onClick: callAll(isClickTriggered && this.scheduleToggle, props.onClick),
       onContextMenu: callAll(
         isRightClickTriggered && this.scheduleToggle,
@@ -187,7 +188,7 @@ export default class TooltipTrigger extends PureComponent {
       <Manager>
         <Reference>
           {({ ref }) =>
-            children({ ref, getTriggerProps: this.getTriggerProps })
+            children({ getTriggerProps: this.getTriggerProps(ref) })
           }
         </Reference>
         {this.state.tooltipShown &&

--- a/src/TooltipTrigger.js
+++ b/src/TooltipTrigger.js
@@ -4,9 +4,8 @@
 import React, { PureComponent } from 'react';
 import { createPortal } from 'react-dom';
 import T from 'prop-types';
-import cn from 'classnames';
 import { Manager, Reference, Popper } from 'react-popper';
-import { renderSlot } from './utils';
+import { callAll } from './utils';
 
 import Tooltip from './Tooltip';
 
@@ -25,27 +24,11 @@ export default class TooltipTrigger extends PureComponent {
     /**
      * trigger
      */
-    children: T.node.isRequired,
+    children: T.func.isRequired,
     /**
      * tooltip
      */
     tooltip: T.node.isRequired,
-    /**
-     * class to be applied to trigger container span
-     */
-    triggerClassName: T.string,
-    /**
-     * style to be applied on trigger container span
-     */
-    triggerStyle: T.object,
-    /**
-     * class to be applied to tooltip container span
-     */
-    tooltipClassName: T.string,
-    /**
-     * style to be applied on tooltip container span
-     */
-    tooltipStyle: T.object,
     /**
      * whether tooltip is shown by default
      */
@@ -166,6 +149,29 @@ export default class TooltipTrigger extends PureComponent {
     this._clearScheduled();
   }
 
+  getTriggerProps = (props = {}) => {
+    const isClickTriggered = this.props.trigger === 'click';
+    const isHoverTriggered = this.props.trigger === 'hover';
+    const isRightClickTriggered = this.props.trigger === 'right-click';
+
+    return {
+      ...props,
+      onClick: callAll(isClickTriggered && this.scheduleToggle, props.onClick),
+      onContextMenu: callAll(
+        isRightClickTriggered && this.scheduleToggle,
+        props.onContextMenu
+      ),
+      onMouseEnter: callAll(
+        isHoverTriggered && this.scheduleShow,
+        props.onMouseEnter
+      ),
+      onMouseLeave: callAll(
+        isHoverTriggered && this.scheduleHide,
+        props.onMouseLeave
+      )
+    };
+  };
+
   render() {
     const {
       children,
@@ -174,36 +180,15 @@ export default class TooltipTrigger extends PureComponent {
       showArrow,
       trigger,
       modifiers,
-      triggerClassName,
-      triggerStyle,
-      tooltipClassName,
-      tooltipStyle,
       closeOnOutOfBoundaries
     } = this.props;
-    const isClickTriggered = trigger === 'click';
-    const isHoverTriggered = trigger === 'hover';
-    const isRightClickTriggered = trigger === 'right-click';
-
-    const eventHandlers = {
-      onClick: isClickTriggered ? this.scheduleToggle : undefined,
-      onContextMenu: isRightClickTriggered ? this.scheduleToggle : undefined,
-      onMouseEnter: isHoverTriggered ? this.scheduleShow : undefined,
-      onMouseLeave: isHoverTriggered ? this.scheduleHide : undefined
-    };
 
     return (
       <Manager>
         <Reference>
-          {({ ref }) => (
-            <span
-              ref={ref}
-              className={cn('trigger', triggerClassName)}
-              style={triggerStyle}
-              {...eventHandlers}
-            >
-              {renderSlot(children)}
-            </span>
-          )}
+          {({ ref }) =>
+            children({ ref, getTriggerProps: this.getTriggerProps })
+          }
         </Reference>
         {this.state.tooltipShown &&
           createPortal(
@@ -233,8 +218,6 @@ export default class TooltipTrigger extends PureComponent {
                         placement,
                         trigger,
                         closeOnOutOfBoundaries,
-                        tooltipClassName,
-                        tooltipStyle,
                         tooltip,
                         addParentOutsideClickHandler,
                         removeParentOutsideClickHandler,

--- a/src/TooltipTrigger.js
+++ b/src/TooltipTrigger.js
@@ -28,7 +28,7 @@ export default class TooltipTrigger extends PureComponent {
     /**
      * tooltip
      */
-    tooltip: T.node.isRequired,
+    tooltip: T.func.isRequired,
     /**
      * whether tooltip is shown by default
      */

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,23 +1,2 @@
-import React from 'react';
-import cn from 'classnames';
-import _ from 'lodash';
-
-export const renderSlot = (El, extraProps = {}) => {
-  if (_.isFunction(El)) {
-    let props = extraProps;
-    if (_.isFunction(extraProps)) {
-      props = props();
-    }
-    return <El {...props} />;
-  }
-  if (React.isValidElement(El)) {
-    let props = extraProps;
-    if (_.isFunction(extraProps)) {
-      props = props(El.props);
-    } else if (props.className) {
-      props.className = cn(props.className, El.props.className);
-    }
-    return React.cloneElement(El, props);
-  }
-  return El;
-};
+export const callAll = (...fns) => (...args) =>
+  fns.forEach(fn => fn && fn(...args));


### PR DESCRIPTION
Here's an idea of using render prop instead of the predefined styles and layout.

The main point here, that the library doesn't render anything itself. it provides required props and this is up to the user how to use them.

The example of use:

```jsx
<TooltipTrigger
  tooltip={({ getTooltipProps, arrowProps, arrowPlacement }) => (
    <div {...getTooltipProps()}>
      <div {...arrowProps} data-placement={arrowPlacement} />I'm the tooltip 
    </div>
  )}
  placement="bottom"
  trigger="click"
>
  {({ getTriggerProps }) => <button {...getTriggerProps()}>CLICK ME</button>}
</TooltipTrigger>
```

TODO:

- [ ] update docs
- [ ] cleanup


What do you think?