### PR TITLE
TS typings: Make props argument in getArrowProps optional

### DIFF
--- a/typings/react-popper-tooltip.d.ts
+++ b/typings/react-popper-tooltip.d.ts
@@ -58,7 +58,7 @@ declare module 'react-popper-tooltip' {
       [key: string]: any;
     };
     tooltipRef: React.RefObject<any>;
-    getArrowProps: (props: any) => {
+    getArrowProps: (props?: any) => {
       style: React.CSSProperties;
       [key: string]: any;
     };


### PR DESCRIPTION
A small fix for an issue I ran into today after trying the bundled typings in 2.3.4.