### PR TITLE
Refactor show/hide/toggle methods

### DIFF
--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -20,7 +20,6 @@ export default class Tooltip extends PureComponent {
     placement: T.string,
     trigger: T.string,
     clearScheduled: T.func,
-    scheduleHide: T.func,
     tooltip: T.func,
     hideTooltip: T.func,
     parentOutsideClickHandler: T.func,
@@ -99,7 +98,7 @@ export default class Tooltip extends PureComponent {
         props.onMouseEnter
       ),
       onMouseLeave: callAll(
-        isHoverTriggered && this.props.scheduleHide,
+        isHoverTriggered && this.props.hideTooltip,
         props.onMouseLeave
       )
     };

--- a/src/TooltipTrigger.js
+++ b/src/TooltipTrigger.js
@@ -89,7 +89,7 @@ export default class TooltipTrigger extends PureComponent {
     clearTimeout(this._showTimeout);
   };
 
-  showTooltip = (delay = this.props.delayShow) => {
+  _showTooltip = (delay = this.props.delayShow) => {
     this._clearScheduled();
 
     this._showTimeout = setTimeout(
@@ -98,7 +98,7 @@ export default class TooltipTrigger extends PureComponent {
     );
   };
 
-  hideTooltip = (delay = this.props.delayHide) => {
+  _hideTooltip = (delay = this.props.delayHide) => {
     this._clearScheduled();
 
     this._hideTimeout = setTimeout(
@@ -107,8 +107,8 @@ export default class TooltipTrigger extends PureComponent {
     );
   };
 
-  toggleTooltip = delay => {
-    const action = this.state.tooltipShown ? 'hideTooltip' : 'showTooltip';
+  _toggleTooltip = delay => {
+    const action = this.state.tooltipShown ? '_hideTooltip' : '_showTooltip';
     this[action](delay);
   };
 
@@ -133,17 +133,17 @@ export default class TooltipTrigger extends PureComponent {
 
     return {
       ...props,
-      onClick: callAll(isClickTriggered && this.toggleTooltip, props.onClick),
+      onClick: callAll(isClickTriggered && this._toggleTooltip, props.onClick),
       onContextMenu: callAll(
         isRightClickTriggered && this._contextMenuToggle,
         props.onContextMenu
       ),
       onMouseEnter: callAll(
-        isHoverTriggered && this.showTooltip,
+        isHoverTriggered && this._showTooltip,
         props.onMouseEnter
       ),
       onMouseLeave: callAll(
-        isHoverTriggered && this.hideTooltip(),
+        isHoverTriggered && this._hideTooltip(),
         props.onMouseLeave
       )
     };
@@ -201,7 +201,7 @@ export default class TooltipTrigger extends PureComponent {
                         scheduleUpdate
                       }}
                       innerRef={ref}
-                      hideTooltip={this.hideTooltip}
+                      hideTooltip={this._hideTooltip}
                       clearScheduled={this._clearScheduled}
                     />
                   )}

--- a/src/TooltipTrigger.js
+++ b/src/TooltipTrigger.js
@@ -89,36 +89,27 @@ export default class TooltipTrigger extends PureComponent {
     clearTimeout(this._showTimeout);
   };
 
-  showTooltip = () => {
+  showTooltip = (delay = this.props.delayShow) => {
     this._clearScheduled();
-    this.setState({ tooltipShown: true });
+
+    this._showTimeout = setTimeout(
+      () => this.setState({ tooltipShown: true }),
+      delay
+    );
   };
 
-  hideTooltip = () => {
+  hideTooltip = (delay = this.props.delayHide) => {
     this._clearScheduled();
-    this.setState({ tooltipShown: false });
+
+    this._hideTimeout = setTimeout(
+      () => this.setState({ tooltipShown: false }),
+      delay
+    );
   };
 
-  toggleTooltip = () => {
-    this._clearScheduled();
-    this.setState(prevState => ({
-      tooltipShown: !prevState.tooltipShown
-    }));
-  };
-
-  scheduleShow = () => {
-    this._clearScheduled();
-    this._showTimeout = setTimeout(this.showTooltip, this.props.delayShow);
-  };
-
-  scheduleHide = () => {
-    this._clearScheduled();
-    this._hideTimeout = setTimeout(this.hideTooltip, this.props.delayHide);
-  };
-
-  scheduleToggle = () => {
-    const action = this.state.tooltipShown ? 'scheduleHide' : 'scheduleShow';
-    this[action]();
+  toggleTooltip = delay => {
+    const action = this.state.tooltipShown ? 'hideTooltip' : 'showTooltip';
+    this[action](delay);
   };
 
   _contextMenuToggle = event => {
@@ -142,17 +133,17 @@ export default class TooltipTrigger extends PureComponent {
 
     return {
       ...props,
-      onClick: callAll(isClickTriggered && this.scheduleToggle, props.onClick),
+      onClick: callAll(isClickTriggered && this.toggleTooltip, props.onClick),
       onContextMenu: callAll(
         isRightClickTriggered && this._contextMenuToggle,
         props.onContextMenu
       ),
       onMouseEnter: callAll(
-        isHoverTriggered && this.scheduleShow,
+        isHoverTriggered && this.showTooltip,
         props.onMouseEnter
       ),
       onMouseLeave: callAll(
-        isHoverTriggered && this.scheduleHide,
+        isHoverTriggered && this.hideTooltip(),
         props.onMouseLeave
       )
     };
@@ -172,7 +163,13 @@ export default class TooltipTrigger extends PureComponent {
       <Manager>
         <Reference>
           {({ ref }) =>
-            children({ getTriggerProps: this.getTriggerProps, triggerRef: ref })
+            children({
+              getTriggerProps: this.getTriggerProps,
+              triggerRef: ref,
+              showTooltip: this.showTooltip,
+              hideTooltip: this.hideTooltip,
+              toggleTooltip: this.toggleTooltip
+            })
           }
         </Reference>
         {this.state.tooltipShown &&
@@ -212,7 +209,6 @@ export default class TooltipTrigger extends PureComponent {
                       innerRef={ref}
                       hideTooltip={this.hideTooltip}
                       clearScheduled={this._clearScheduled}
-                      scheduleHide={this.scheduleHide}
                     />
                   )}
                 </TooltipContext.Consumer>

--- a/src/TooltipTrigger.js
+++ b/src/TooltipTrigger.js
@@ -163,13 +163,7 @@ export default class TooltipTrigger extends PureComponent {
       <Manager>
         <Reference>
           {({ ref }) =>
-            children({
-              getTriggerProps: this.getTriggerProps,
-              triggerRef: ref,
-              showTooltip: this.showTooltip,
-              hideTooltip: this.hideTooltip,
-              toggleTooltip: this.toggleTooltip
-            })
+            children({ getTriggerProps: this.getTriggerProps, triggerRef: ref })
           }
         </Reference>
         {this.state.tooltipShown &&


### PR DESCRIPTION
I refactored `showTooltip`/ `hideTooltip`/`toggleTooltip` methods and removed their scheduled versions. The updated ones can do the same. They accept a number as an argument. If the argument is undefined, `delayShow`/`delayHide` props used as defaults. 

You can pass zero to instantly show/hide the tooltip.