### PR TITLE
Add onVisibilityChange, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Use this prop if you want to control the visibility state of the tooltip.
 
 `react-popper-tooltip` manages its own state internally. You can use this prop to pass the 
 visibility state of the tooltip from the outside. You will be required to keep this state up to 
-date (this is where `onVisibilityChange` becomes usefull), but you can also control the state 
+date (this is where `onVisibilityChange` becomes useful), but you can also control the state 
 from anywhere, be that state from other components, `redux`, `react-router`, or anywhere else.
 
 ### delayShow

--- a/README.md
+++ b/README.md
@@ -154,14 +154,22 @@ the section "[Children and tooltip functions](#children-and-tooltip-functions)".
 
 This is the initial visibility state of the tooltip.
 
+### onVisibilityChange
+
+> `function(tooltipShown: boolean)`
+
+Called when the visibility of the tooltip changes. `tooltipShown` is a new state.
+
 ### tooltipShown
 
 > `boolean` | **control prop**
 
 Use this prop if you want to control the visibility state of the tooltip.
 
-Package manages its own state internally. You can use this prop to pass the visibility state of the
-tooltip from the outside.
+`react-popper-tooltip` manages its own state internally. You can use this prop to pass the 
+visibility state of the tooltip from the outside. You will be required to keep this state up to 
+date (this is where `onVisibilityChange` becomes usefull), but you can also control the state 
+from anywhere, be that state from other components, `redux`, `react-router`, or anywhere else.
 
 ### delayShow
 
@@ -220,15 +228,6 @@ Modifiers, applied by default:
   }
 }
 ```
-
-You also have the ability to attach ref to the `TooltipTrigger` component which exposes following 
-methods for programmatic control of the tooltip:
-- `showTooltip` (show immediately)
-- `hideTooltip` (hide immediately)
-- `toggleTooltip` (toggle immediately)
-- `scheduleShow` (show respecting delayShow prop)
-- `scheduleHide` (hide respecting delayHide prop)
-- `scheduleToggle` (toggle respecting delayShow and delayHide props)
 
 ## Children and tooltip functions
 

--- a/src/TooltipTrigger.js
+++ b/src/TooltipTrigger.js
@@ -82,7 +82,7 @@ export default class TooltipTrigger extends PureComponent {
     placement: 'right',
     trigger: 'hover',
     closeOnOutOfBoundaries: true,
-    onChange: noop
+    onVisibilityChange: noop
   };
 
   state = {

--- a/src/TooltipTrigger.js
+++ b/src/TooltipTrigger.js
@@ -86,9 +86,7 @@ export default class TooltipTrigger extends PureComponent {
   };
 
   state = {
-    tooltipShown: this._isControlled()
-      ? false
-      : this.props.defaultTooltipShown || false
+    tooltipShown: this._isControlled() ? false : this.props.defaultTooltipShown
   };
 
   _isControlled() {

--- a/src/TooltipTrigger.js
+++ b/src/TooltipTrigger.js
@@ -36,7 +36,7 @@ export default class TooltipTrigger extends PureComponent {
      */
     tooltipShown: T.bool,
     /**
-     * use to create controlled tooltip
+     * сalled when the visibility of the tooltip changes
      */
     onVisibilityChange: T.func,
     /**

--- a/src/TooltipTrigger.js
+++ b/src/TooltipTrigger.js
@@ -87,7 +87,7 @@ export default class TooltipTrigger extends PureComponent {
 
   state = {
     tooltipShown: this._isControlled()
-      ? undefined
+      ? false
       : this.props.defaultTooltipShown || false
   };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,2 +1,4 @@
 export const callAll = (...fns) => (...args) =>
   fns.forEach(fn => fn && fn(...args));
+
+export const noop = () => {};


### PR DESCRIPTION
I've added `onVisibilityChange` callback which invoked every time the tooltip visibility state changes. 

I also made the refactor. Now if the component controlled (`tooltipShown` prop and external state used), our code doesn't have the internal state at all and completely rely on external `tooltipShown` 

That means we can remove `getDerivedStateFromProps` as we don't need to synchronize the internal state with external changes.

I also updated the README according to the new changes and removed the `TooltipTrigger` ref part. We shouldn't recommend using the ref this way.