### PR TITLE
Add main entry for node resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/mohsinulhaq/react-popper-tooltip"
   },
   "browser": "lib/cjs/index.js",
+   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "unpkg": "dist/index.js",
   "style": "dist/styles.css",


### PR DESCRIPTION
Otherwise react-popper-tooltip can't be used in a server-side render environment.