### PR TITLE
Expose trigger reference

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dist/index.js": {
-    "bundled": 7445,
-    "minified": 7445,
-    "gzipped": 2208
+    "bundled": 7468,
+    "minified": 7468,
+    "gzipped": 2216
   },
   "lib/cjs/index.js": {
-    "bundled": 14012,
-    "minified": 7765,
-    "gzipped": 2141
+    "bundled": 14087,
+    "minified": 7788,
+    "gzipped": 2146
   },
   "lib/esm/index.js": {
-    "bundled": 13960,
-    "minified": 7732,
-    "gzipped": 2138,
+    "bundled": 14035,
+    "minified": 7755,
+    "gzipped": 2143,
     "treeshaked": {
       "rollup": {
-        "code": 7171,
+        "code": 7194,
         "import_statements": 331
       },
       "webpack": {
-        "code": 8405
+        "code": 8428
       }
     }
   }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dist/index.js": {
-    "bundled": 7468,
-    "minified": 7468,
-    "gzipped": 2216
+    "bundled": 7471,
+    "minified": 7471,
+    "gzipped": 2219
   },
   "lib/cjs/index.js": {
-    "bundled": 14087,
-    "minified": 7788,
-    "gzipped": 2146
+    "bundled": 14096,
+    "minified": 7791,
+    "gzipped": 2148
   },
   "lib/esm/index.js": {
-    "bundled": 14035,
-    "minified": 7755,
-    "gzipped": 2143,
+    "bundled": 14044,
+    "minified": 7758,
+    "gzipped": 2144,
     "treeshaked": {
       "rollup": {
-        "code": 7194,
+        "code": 7197,
         "import_statements": 331
       },
       "webpack": {
-        "code": 8428
+        "code": 8431
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Each placement can have a variation from this list:
 
 The event that triggers the tooltip. One of `click`, `hover`, `right-click`, `none`.
 
-### triggerRef
+### getTriggerRef
 
 > `function(HTMLElement) => void` 
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The event that triggers the tooltip. One of `click`, `hover`, `right-click`, `no
 
 > `function(HTMLElement) => void` 
 
-Function that can be used to obtain trigger reference.
+Function that can be used to obtain a trigger element reference.
 
 ### closeOnOutOfBoundaries
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,12 @@ Each placement can have a variation from this list:
 
 The event that triggers the tooltip. One of `click`, `hover`, `right-click`, `none`.
 
+### triggerRef
+
+> `function(HTMLElement) => void` 
+
+Function that can be used to obtain trigger reference.
+
 ### closeOnOutOfBoundaries
 
 > `boolean` | defaults to `true`

--- a/src/TooltipTrigger.js
+++ b/src/TooltipTrigger.js
@@ -62,6 +62,10 @@ export default class TooltipTrigger extends Component {
      */
     trigger: T.oneOf(['click', 'hover', 'right-click', 'none']),
     /**
+     * function that can be used to obtain trigger reference
+     */
+    triggerRef: T.func,
+    /**
      * whether to close the tooltip when it's trigger is out of the boundary
      */
     closeOnOutOfBoundaries: T.bool,
@@ -211,6 +215,7 @@ export default class TooltipTrigger extends Component {
       tooltip,
       placement,
       trigger,
+      triggerRef,
       modifiers,
       closeOnOutOfBoundaries,
       usePortal,
@@ -273,7 +278,7 @@ export default class TooltipTrigger extends Component {
 
     return (
       <Manager>
-        <Reference>
+        <Reference innerRef={triggerRef}>
           {({ ref }) =>
             children({ getTriggerProps: this.getTriggerProps, triggerRef: ref })
           }

--- a/src/TooltipTrigger.js
+++ b/src/TooltipTrigger.js
@@ -62,7 +62,7 @@ export default class TooltipTrigger extends Component {
      */
     trigger: T.oneOf(['click', 'hover', 'right-click', 'none']),
     /**
-     * function that can be used to obtain trigger reference
+     * function that can be used to obtain a trigger element reference
      */
     getTriggerRef: T.func,
     /**

--- a/src/TooltipTrigger.js
+++ b/src/TooltipTrigger.js
@@ -64,7 +64,7 @@ export default class TooltipTrigger extends Component {
     /**
      * function that can be used to obtain trigger reference
      */
-    triggerRef: T.func,
+    getTriggerRef: T.func,
     /**
      * whether to close the tooltip when it's trigger is out of the boundary
      */
@@ -215,7 +215,7 @@ export default class TooltipTrigger extends Component {
       tooltip,
       placement,
       trigger,
-      triggerRef,
+      getTriggerRef,
       modifiers,
       closeOnOutOfBoundaries,
       usePortal,
@@ -278,7 +278,7 @@ export default class TooltipTrigger extends Component {
 
     return (
       <Manager>
-        <Reference innerRef={triggerRef}>
+        <Reference innerRef={getTriggerRef}>
           {({ ref }) =>
             children({ getTriggerProps: this.getTriggerProps, triggerRef: ref })
           }


### PR DESCRIPTION
This PR introduces the prop which can be used to obtain trigger ref.

Here's the simple example where it can be useful.

```
<TooltipTrigger
  tooltip={...}
>
  {({ getTriggerProps, triggerRef }) => (
    <button {...getTriggerProps({ ref: triggerRef })}>Click to start</button>
  )}
</TooltipTrigger>
```

We can't get button ref and use it from outside, for example, to focus the button on a component mount. Now, we use the ref internally and don't expose it.

This PR resolves this issue.

```
<TooltipTrigger
  getTriggerRef={node => this.buttonRef = node}
  tooltip={...}
>
  {({ getTriggerProps, triggerRef }) => (
    <button {...getTriggerProps({ ref: triggerRef })}>Click to start</button>
  )}
</TooltipTrigger>
```
Now we have `buttonRef` and can do whatewer we want.


