### PR TITLE
[index] Export TS types & interfaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
 import TooltipTrigger from './TooltipTrigger';
+
+export * from './types';
 export default TooltipTrigger;


### PR DESCRIPTION
Add export for all TS types & interfaces for easy import & extend when building custom components.

eg: `import TooltipTrigger, { ChildrenArg, TooltipArg } from 'react-popper-tooltip';`

P.S.: Thanks for the package @mohsinulhaq :)