### PR TITLE
use cross-browser compatible API for viewport overflow calculation

### DIFF
--- a/src/TooltipTrigger.tsx
+++ b/src/TooltipTrigger.tsx
@@ -105,11 +105,11 @@ class TooltipTrigger extends Component<
             const { pageX, pageY } = this.state;
             const { width, height } = this.popperOffset;
             const x =
-              pageX! + width > window.scrollX + document.body.offsetWidth
+              pageX! + width > window.pageXOffset + document.body.offsetWidth
                 ? pageX! - width
                 : pageX;
             const y =
-              pageY! + height > window.scrollY + document.body.offsetHeight
+              pageY! + height > window.pageYOffset + document.body.offsetHeight
                 ? pageY! - height
                 : pageY;
             style.transform = `translate3d(${x}px, ${y}px, 0`;


### PR DESCRIPTION
When a TooltipTrigger is used with a followCursor flag the tooltip is out of viewport. 
window.scrollX and window.scrollY are not working in IE. Changed to window.pageXOffset and window.pageYOffset for cross-browser compatibility