### PR TITLE
support react and react-dom 17 as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,13 +49,13 @@
   "author": "Mohsin Ul Haq <mohsinulhaq01@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^16.6.0",
-    "react-dom": "^16.6.0"
+    "react": "^16.6.0 || ^17.0.0",
+    "react-dom": "^16.6.0 || ^17.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.10.4",
     "@popperjs/core": "^2.4.4",
-    "react-popper": "^2.2.3"
+    "react-popper": "^2.2.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11980,10 +11980,10 @@ react-live@^2.2.1:
     react-simple-code-editor "^0.10.0"
     unescape "^1.0.1"
 
-react-popper@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
-  integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==
+react-popper@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.4.tgz#d2ad3d2474ac9f1abf93df3099d408e5aa6a2e22"
+  integrity sha512-NacOu4zWupdQjVXq02XpTD3yFPSfg5a7fex0wa3uGKVkFK7UN6LvVxgcb+xYr56UCuWiNPMH20tntdVdJRwYew==
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"


### PR DESCRIPTION
Changes:
- Add `^17.0.0` to peer dependencies.
- Update `react-popper` to [v2.2.4](https://github.com/popperjs/react-popper/releases/tag/v2.2.4) which adds React 17 support.

**Edit:** Hadn't seen #99. Only addition here is that I bumped `react-popper`. Feel free to close this if you'd like to proceed with the other PR.