### PR TITLE
change default offset to [0, 7]

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,10 @@ Options to [MutationObserver
 visible and its content changes, it automatically repositions itself. In some cases
 you may need to change which parameters to observe or opt-out of tracking the changes at all.
 
-- `offset: [number, number]`, defaults to `[0, 6]`
+- `offset: [number, number]`, defaults to `[0, 7]`
 
 This is a shorthand for `popperOptions.modifiers` offset modifier option. The default value means the tooltip will be
-placed 6px away from the trigger element (to reserve enough space for the arrow element).
+placed 7px away from the trigger element (to reserve enough space for the arrow element).
 
 We use this default value to match the size of the arrow element from our default CSS file. Feel free to change it if you are using your
 own styles.

--- a/README.md
+++ b/README.md
@@ -164,10 +164,10 @@ Options to [MutationObserver
 visible and its content changes, it automatically repositions itself. In some cases
 you may need to change which parameters to observe or opt-out of tracking the changes at all.
 
-- `offset: [number, number]`, defaults to `[0, 4]`
+- `offset: [number, number]`, defaults to `[0, 6]`
 
 This is a shorthand for `popperOptions.modifiers` offset modifier option. The default value means the tooltip will be
-placed 4px away from the trigger element (to reserve enough space for the arrow element).
+placed 6px away from the trigger element (to reserve enough space for the arrow element).
 
 We use this default value to match the size of the arrow element from our default CSS file. Feel free to change it if you are using your
 own styles.

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,7 @@ export type Config = {
   placement?: PopperJS.Placement;
   /**
    * Shorthand for popper.js offset modifier, see https://popper.js.org/docs/v2/modifiers/offset/
-   * @default [0, 6]
+   * @default [0, 7]
    */
   offset?: [number, number];
 };

--- a/src/usePopperTooltip.ts
+++ b/src/usePopperTooltip.ts
@@ -24,7 +24,7 @@ const defaultConfig: Config = {
     childList: true,
     subtree: true,
   },
-  offset: [0, 4],
+  offset: [0, 6],
   trigger: 'hover',
 };
 

--- a/src/usePopperTooltip.ts
+++ b/src/usePopperTooltip.ts
@@ -24,7 +24,7 @@ const defaultConfig: Config = {
     childList: true,
     subtree: true,
   },
-  offset: [0, 6],
+  offset: [0, 7],
   trigger: 'hover',
 };
 


### PR DESCRIPTION
With 4px the arrow overlaps the trigger element and it creates a visual glitch when the cursor hovers a trigger exactly at the place where it overlaps.