### PR TITLE
improve hover outside handler logic

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,6 +1,6 @@
 {
   "react-popper-tooltip.js": {
-    "bundled": 12727,
+    "bundled": 12843,
     "minified": 5628,
     "gzipped": 1966,
     "treeshaked": {

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,15 +1,15 @@
 {
   "react-popper-tooltip.js": {
-    "bundled": 10503,
-    "minified": 5012,
-    "gzipped": 1723,
+    "bundled": 12727,
+    "minified": 5628,
+    "gzipped": 1966,
     "treeshaked": {
       "rollup": {
         "code": 142,
         "import_statements": 142
       },
       "webpack": {
-        "code": 1355
+        "code": 1369
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Options to [MutationObserver
 visible and its content changes, it automatically repositions itself. In some cases
 you may need to change which parameters to observe or opt-out of tracking the changes at all.
 
-- `offset: [number, number]`, defaults to `[0, 7]`
+- `offset: [number, number]`, defaults to `[0, 6]`
 
 This is a shorthand for `popperOptions.modifiers` offset modifier option. The default value means the tooltip will be
 placed 7px away from the trigger element (to reserve enough space for the arrow element).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-popper-tooltip",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "React tooltip library built around react-popper",
   "author": "Mohsin Ul Haq <mohsinulhaq01@gmail.com>",
   "license": "MIT",
@@ -47,7 +47,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn typecheck && yarn build && yarn test && lint-staged"
+      "pre-commit": "yarn typecheck && yarn build && yarn test && lint-staged && git add .size-snapshot.json"
     }
   },
   "lint-staged": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,7 @@ export type Config = {
   placement?: PopperJS.Placement;
   /**
    * Shorthand for popper.js offset modifier, see https://popper.js.org/docs/v2/modifiers/offset/
-   * @default [0, 7]
+   * @default [0, 6]
    */
   offset?: [number, number];
 };

--- a/src/usePopperTooltip.ts
+++ b/src/usePopperTooltip.ts
@@ -4,6 +4,7 @@ import {
   useControlledState,
   useGetLatest,
   generateBoundingClientRect,
+  isMouseOutside,
 } from './utils';
 import { Config, PopperOptions, PropsGetterArgs, TriggerType } from './types';
 
@@ -182,12 +183,29 @@ export function usePopperTooltip(
     if (triggerRef == null || !isTriggeredBy('hover')) return;
 
     triggerRef.addEventListener('mouseenter', showTooltip);
-    triggerRef.addEventListener('mouseleave', hideTooltip);
     return () => {
       triggerRef.removeEventListener('mouseenter', showTooltip);
-      triggerRef.removeEventListener('mouseleave', hideTooltip);
     };
   }, [triggerRef, isTriggeredBy, showTooltip, hideTooltip]);
+  React.useEffect(() => {
+    if (!visible || triggerRef == null || !isTriggeredBy('hover')) return;
+
+    const handleMouseMove = (event: MouseEvent) => {
+      if (
+        isMouseOutside(
+          event,
+          triggerRef,
+          getLatest().finalConfig.interactive && tooltipRef
+        )
+      ) {
+        hideTooltip();
+      }
+    };
+    window.addEventListener('mousemove', handleMouseMove);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+    };
+  }, [getLatest, hideTooltip, isTriggeredBy, tooltipRef, triggerRef, visible]);
 
   // Trigger: hover on tooltip, keep it open if hovered
   React.useEffect(() => {

--- a/src/usePopperTooltip.ts
+++ b/src/usePopperTooltip.ts
@@ -198,24 +198,26 @@ export function usePopperTooltip(
       return;
     }
 
+    let lastMouseOutside = false;
     const handleMouseMove = (event: MouseEvent) => {
-      if (
-        isMouseOutside(
-          event,
-          triggerRef,
-          !finalConfig.followCursor &&
-            getLatest().finalConfig.interactive &&
-            tooltipRef
-        )
-      ) {
+      const mouseOutside = isMouseOutside(
+        event,
+        triggerRef,
+        !finalConfig.followCursor &&
+          getLatest().finalConfig.interactive &&
+          tooltipRef
+      );
+      if (mouseOutside && lastMouseOutside !== mouseOutside) {
         hideTooltip();
-      } else if (finalConfig.followCursor) {
+      }
+      if (!mouseOutside && finalConfig.followCursor) {
         virtualElement.getBoundingClientRect = generateBoundingClientRect(
           event.clientX,
           event.clientY
         );
         update?.();
       }
+      lastMouseOutside = mouseOutside;
     };
     window.addEventListener('mousemove', handleMouseMove);
     return () => {

--- a/src/usePopperTooltip.ts
+++ b/src/usePopperTooltip.ts
@@ -27,7 +27,7 @@ const defaultConfig: Config = {
     childList: true,
     subtree: true,
   },
-  offset: [0, 7],
+  offset: [0, 6],
   trigger: 'hover',
 };
 

--- a/src/usePopperTooltip.ts
+++ b/src/usePopperTooltip.ts
@@ -50,6 +50,7 @@ export function usePopperTooltip(
 
   const defaultModifiers = React.useMemo(
     () => [{ name: 'offset', options: { offset: finalConfig.offset } }],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     isArray(finalConfig.offset) ? finalConfig.offset : []
   );
 
@@ -90,6 +91,7 @@ export function usePopperTooltip(
         ? finalConfig.trigger.includes(trigger)
         : finalConfig.trigger === trigger;
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     isArray(finalConfig.trigger) ? finalConfig.trigger : [finalConfig.trigger]
   );
 

--- a/src/usePopperTooltip.ts
+++ b/src/usePopperTooltip.ts
@@ -274,9 +274,6 @@ export function usePopperTooltip(
       style: {
         ...args.style,
         ...styles.popper,
-        ...(finalConfig.followCursor && {
-          pointerEvents: 'none' as React.CSSProperties['pointerEvents'],
-        }),
       },
       ...attributes.popper,
     };

--- a/src/usePopperTooltip.ts
+++ b/src/usePopperTooltip.ts
@@ -7,6 +7,8 @@ import {
 } from './utils';
 import { Config, PopperOptions, PropsGetterArgs, TriggerType } from './types';
 
+const { isArray } = Array;
+
 const virtualElement = {
   getBoundingClientRect: generateBoundingClientRect(),
 };
@@ -47,7 +49,7 @@ export function usePopperTooltip(
 
   const defaultModifiers = React.useMemo(
     () => [{ name: 'offset', options: { offset: finalConfig.offset } }],
-    [finalConfig.offset]
+    isArray(finalConfig.offset) ? finalConfig.offset : []
   );
 
   const finalPopperOptions = {
@@ -83,11 +85,11 @@ export function usePopperTooltip(
 
   const isTriggeredBy = React.useCallback(
     (trigger: TriggerType) => {
-      return Array.isArray(finalConfig.trigger)
+      return isArray(finalConfig.trigger)
         ? finalConfig.trigger.includes(trigger)
         : finalConfig.trigger === trigger;
     },
-    [finalConfig.trigger]
+    isArray(finalConfig.trigger) ? finalConfig.trigger : [finalConfig.trigger]
   );
 
   const hideTooltip = React.useCallback(() => {

--- a/stories/basic.stories.tsx
+++ b/stories/basic.stories.tsx
@@ -37,16 +37,16 @@ export const Example: Story<Config> = (props) => {
 };
 
 Example.argTypes = {
-  trigger: {
+  delayHide: {
     control: {
-      type: 'select',
-      options: ['hover', 'click', 'right-click', 'focus', null],
+      type: 'number',
+      options: { min: 0, step: 1 },
     },
   },
-  placement: {
+  delayShow: {
     control: {
-      type: 'select',
-      options: ['top', 'right', 'bottom', 'left'],
+      type: 'number',
+      options: { min: 0, step: 1 },
     },
   },
   followCursor: {
@@ -57,6 +57,18 @@ Example.argTypes = {
   interactive: {
     control: {
       type: 'boolean',
+    },
+  },
+  placement: {
+    control: {
+      type: 'select',
+      options: ['top', 'right', 'bottom', 'left'],
+    },
+  },
+  trigger: {
+    control: {
+      type: 'select',
+      options: ['hover', 'click', 'right-click', 'focus', null],
     },
   },
 };

--- a/stories/basic.stories.tsx
+++ b/stories/basic.stories.tsx
@@ -54,6 +54,11 @@ Example.argTypes = {
       type: 'boolean',
     },
   },
+  interactive: {
+    control: {
+      type: 'boolean',
+    },
+  },
 };
 
 export default {

--- a/tests/usePopperTooltip.spec.tsx
+++ b/tests/usePopperTooltip.spec.tsx
@@ -47,7 +47,10 @@ describe('trigger option', () => {
     expect(await screen.findByText(TooltipText)).toBeInTheDocument();
 
     // tooltip hidden on hover out
-    userEvent.unhover(screen.getByText(TriggerText));
+    userEvent.unhover(screen.getByText(TriggerText), {
+      clientX: 1,
+      clientY: 1,
+    });
     await waitFor(() => {
       expect(screen.queryByText(TooltipText)).not.toBeInTheDocument();
     });
@@ -197,7 +200,10 @@ test('delayHide option removes tooltip after specified delay', async () => {
   });
   expect(await screen.findByText(TooltipText)).toBeInTheDocument();
 
-  userEvent.unhover(screen.getByText(TriggerText));
+  userEvent.unhover(screen.getByText(TriggerText), {
+    clientX: 1,
+    clientY: 1,
+  });
   // Still present after 2000ms
   act(() => {
     jest.advanceTimersByTime(2000);
@@ -235,7 +241,10 @@ test('onVisibleChange option called when state changes', async () => {
   expect(onVisibleChange).toHaveBeenLastCalledWith(true);
 
   // Now visible, change visible to false when unhover
-  userEvent.unhover(screen.getByText(TriggerText));
+  userEvent.unhover(screen.getByText(TriggerText), {
+    clientX: 1,
+    clientY: 1,
+  });
   await waitFor(() => {
     expect(screen.queryByText(TooltipText)).not.toBeInTheDocument();
   });

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -78,5 +78,17 @@ describe('isMouseOutside', () => {
     expect(isMouseOutside(mouseEvent(120, 95), trigger, tooltipAbove)).toBe(
       false
     );
+    const tooltipRight = element(150, 110, 40, 20);
+    expect(isMouseOutside(mouseEvent(145, 120), trigger, tooltipRight)).toBe(
+      false
+    );
+    const tooltipBottom = element(100, 150, 40, 20);
+    expect(isMouseOutside(mouseEvent(120, 145), trigger, tooltipBottom)).toBe(
+      false
+    );
+    const tooltipLeft = element(50, 110, 40, 20);
+    expect(isMouseOutside(mouseEvent(95, 120), trigger, tooltipLeft)).toBe(
+      false
+    );
   });
 });

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -1,0 +1,82 @@
+import { isMouseOutside } from '../src/utils';
+
+describe('isMouseOutside', () => {
+  const mouseEvent = (x: number, y: number) =>
+    (({ clientX: x, clientY: y, pageX: x, pageY: y } as unknown) as MouseEvent);
+  const element = (x: number, y: number, width: number, height: number) =>
+    (({
+      getBoundingClientRect: () => ({
+        bottom: y + height,
+        height,
+        left: x,
+        right: x + width,
+        top: y,
+        width,
+        x,
+        y,
+      }),
+    } as unknown) as HTMLElement);
+  it('should detect mouse inside Trigger', () => {
+    const event = mouseEvent(20, 20);
+    const trigger = element(0, 0, 40, 40);
+    expect(isMouseOutside(event, trigger)).toBe(false);
+  });
+  it('should detect mouse outside Trigger', () => {
+    const trigger = element(0, 0, 40, 40);
+    expect(isMouseOutside(mouseEvent(60, 20), trigger)).toBe(true);
+    expect(isMouseOutside(mouseEvent(20, 60), trigger)).toBe(true);
+  });
+  it('should detect mouse at the edge as _inside_ the Trigger', () => {
+    const trigger = element(0, 0, 40, 40);
+    expect(isMouseOutside(mouseEvent(40, 20), trigger)).toBe(false);
+    expect(isMouseOutside(mouseEvent(20, 40), trigger)).toBe(false);
+    expect(isMouseOutside(mouseEvent(40, 40), trigger)).toBe(false);
+    expect(isMouseOutside(mouseEvent(0, 0), trigger)).toBe(false);
+  });
+  it('should round the size of the Trigger up (expand) for mouse event does not support fractional pixels', () => {
+    const trigger = element(0.1, 0.1, 39.1, 39.1);
+    expect(isMouseOutside(mouseEvent(40, 20), trigger)).toBe(false);
+    expect(isMouseOutside(mouseEvent(0, 20), trigger)).toBe(false);
+    expect(isMouseOutside(mouseEvent(20, 40), trigger)).toBe(false);
+    expect(isMouseOutside(mouseEvent(20, 0), trigger)).toBe(false);
+    expect(isMouseOutside(mouseEvent(0, 0), trigger)).toBe(false);
+  });
+  it('should detect mouse inside the tooltip, when provided', () => {
+    const trigger = element(100, 100, 40, 40);
+    const tooltipAbove = element(100, 50, 40, 40);
+    // inside the Tooltip
+    expect(isMouseOutside(mouseEvent(120, 80), trigger, tooltipAbove)).toBe(
+      false
+    );
+    // insite the Trigger
+    expect(isMouseOutside(mouseEvent(120, 120), trigger, tooltipAbove)).toBe(
+      false
+    );
+    // at the edge of the Tooltip
+    expect(isMouseOutside(mouseEvent(100, 50), trigger, tooltipAbove)).toBe(
+      false
+    );
+    // at the edge of the Trigger
+    expect(isMouseOutside(mouseEvent(100, 100), trigger, tooltipAbove)).toBe(
+      false
+    );
+  });
+  it('should detect mouse outside the tooltip, when provided', () => {
+    const trigger = element(100, 100, 40, 40);
+    const tooltipAbove = element(100, 50, 40, 40);
+    expect(isMouseOutside(mouseEvent(0, 0), trigger, tooltipAbove)).toBe(true);
+    expect(isMouseOutside(mouseEvent(99, 70), trigger, tooltipAbove)).toBe(
+      true
+    );
+    expect(isMouseOutside(mouseEvent(120, 49), trigger, tooltipAbove)).toBe(
+      true
+    );
+  });
+  it('should detect mouse in the gap between Tooltip and the Trigger', () => {
+    const trigger = element(100, 100, 40, 40);
+    const tooltipAbove = element(100, 50, 40, 40);
+    expect(isMouseOutside(mouseEvent(120, 95), trigger, tooltipAbove)).toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
This fixes the flickering problem when `trigger="hover"` and Trigger and Tooltip overlaps.

Partially relates #114

First commit also fixes some memoization bugs.