### PR TITLE
fix: tooltip appears unintended with `delayShow`

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "react-popper-tooltip.js": {
-    "bundled": 12843,
-    "minified": 5628,
-    "gzipped": 1966,
+    "bundled": 13122,
+    "minified": 5721,
+    "gzipped": 1998,
     "treeshaked": {
       "rollup": {
         "code": 142,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "react-popper-tooltip.js": {
-    "bundled": 13126,
-    "minified": 5784,
-    "gzipped": 2004,
+    "bundled": 13181,
+    "minified": 5782,
+    "gzipped": 2003,
     "treeshaked": {
       "rollup": {
         "code": 142,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "react-popper-tooltip.js": {
-    "bundled": 13122,
-    "minified": 5721,
-    "gzipped": 1998,
+    "bundled": 13126,
+    "minified": 5784,
+    "gzipped": 2004,
     "treeshaked": {
       "rollup": {
         "code": 142,

--- a/src/usePopperTooltip.ts
+++ b/src/usePopperTooltip.ts
@@ -184,11 +184,16 @@ export function usePopperTooltip(
     if (triggerRef == null || !isTriggeredBy('hover')) return;
 
     triggerRef.addEventListener('mouseenter', showTooltip);
-    const stopTimer = !visible && (() => clearTimeout(timer.current));
-    stopTimer && triggerRef.addEventListener('mouseleave', stopTimer);
+    let stopTimer: undefined | (() => void);
+    if (!visible) {
+      stopTimer = () => clearTimeout(timer.current);
+      triggerRef.addEventListener('mouseleave', stopTimer);
+    }
     return () => {
       triggerRef.removeEventListener('mouseenter', showTooltip);
-      stopTimer && triggerRef.removeEventListener('mouseleave', stopTimer);
+      if (stopTimer) {
+        triggerRef.removeEventListener('mouseleave', stopTimer);
+      }
     };
   }, [isTriggeredBy, hideTooltip, showTooltip, triggerRef, visible]);
   // Listen for mouse exiting the hover area &&

--- a/stories/basic.stories.tsx
+++ b/stories/basic.stories.tsx
@@ -3,11 +3,12 @@ import { Story, Meta } from '@storybook/react';
 import { usePopperTooltip, Config } from '../src';
 import '../src/styles.css';
 
-export const Example: Story<Config & { offsetDistance?: number }> = ({
-  // eslint-disable-next-line react/prop-types
+type ExampleProps = Config & { offsetDistance?: number };
+
+export const Example: Story<ExampleProps> = ({
   offsetDistance,
   ...props
-}) => {
+}: ExampleProps) => {
   const [shown, setShown] = React.useState(false);
   const {
     visible,

--- a/stories/basic.stories.tsx
+++ b/stories/basic.stories.tsx
@@ -5,7 +5,7 @@ import '../src/styles.css';
 
 export const Example: Story<Config & { offsetDistance?: number }> = ({
   // eslint-disable-next-line react/prop-types
-  offsetDistance = 6,
+  offsetDistance,
   ...props
 }) => {
   const [shown, setShown] = React.useState(false);
@@ -69,6 +69,7 @@ Example.argTypes = {
       type: 'number',
       options: { min: 0, step: 1 },
     },
+    defaultValue: 6,
   },
   placement: {
     control: {

--- a/stories/basic.stories.tsx
+++ b/stories/basic.stories.tsx
@@ -3,7 +3,11 @@ import { Story, Meta } from '@storybook/react';
 import { usePopperTooltip, Config } from '../src';
 import '../src/styles.css';
 
-export const Example: Story<Config> = (props) => {
+export const Example: Story<Config & { offsetDistance?: number }> = ({
+  // eslint-disable-next-line react/prop-types
+  offsetDistance = 6,
+  ...props
+}) => {
   const [shown, setShown] = React.useState(false);
   const {
     visible,
@@ -13,8 +17,9 @@ export const Example: Story<Config> = (props) => {
     getTooltipProps,
   } = usePopperTooltip({
     ...props,
-    visible: shown,
+    offset: [0, offsetDistance],
     onVisibleChange: setShown,
+    visible: shown,
   });
 
   return (
@@ -57,6 +62,12 @@ Example.argTypes = {
   interactive: {
     control: {
       type: 'boolean',
+    },
+  },
+  offsetDistance: {
+    control: {
+      type: 'number',
+      options: { min: 0, step: 1 },
     },
   },
   placement: {


### PR DESCRIPTION
Clear the `showTooltip` timeout on `mouseleave`.
Also fix the potential memory leak with wrong `useEffect` call.
And improve Storybook story to allow simulate various `offset`.

fixes #117