### PR TITLE
fix: wrong hover detection with scrollbar

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "react-popper-tooltip.js": {
-    "bundled": 12843,
-    "minified": 5628,
-    "gzipped": 1966,
+    "bundled": 12745,
+    "minified": 5589,
+    "gzipped": 1947,
     "treeshaked": {
       "rollup": {
         "code": 142,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "react-popper-tooltip.js": {
-    "bundled": 12745,
-    "minified": 5589,
-    "gzipped": 1947,
+    "bundled": 13000,
+    "minified": 5597,
+    "gzipped": 1953,
     "treeshaked": {
       "rollup": {
         "code": 142,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,15 +64,15 @@ export function generateBoundingClientRect(x = 0, y = 0) {
 // pageX cannot be supplied in the tests, so we fallback to clientX
 // @see https://github.com/testing-library/dom-testing-library/issues/144
 const mouseOutsideRect = (
-  { clientX, clientY, pageX, pageY }: MouseEvent,
+  { clientX, clientY }: MouseEvent,
   { bottom, left, right, top }: DOMRect
 ) =>
   // DOMRect contains fractional pixel values but MouseEvent reports integers,
   // so we round DOMRect boundaries to make DOMRect slightly bigger
-  (pageX || clientX) < Math.floor(left) ||
-  (pageX || clientX) > Math.ceil(right) ||
-  (pageY || clientY) < Math.floor(top) ||
-  (pageY || clientY) > Math.ceil(bottom);
+  clientX < Math.floor(left) ||
+  clientX > Math.ceil(right) ||
+  clientY < Math.floor(top) ||
+  clientY > Math.ceil(bottom);
 
 /**
  * Checks if mouseevent is triggered outside triggerRef and tooltipRef.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,13 +66,19 @@ export function generateBoundingClientRect(x = 0, y = 0) {
 const mouseOutsideRect = (
   { clientX, clientY }: MouseEvent,
   { bottom, left, right, top }: DOMRect
-) =>
+) => {
   // DOMRect contains fractional pixel values but MouseEvent reports integers,
-  // so we round DOMRect boundaries to make DOMRect slightly bigger
-  clientX < Math.floor(left) ||
-  clientX > Math.ceil(right) ||
-  clientY < Math.floor(top) ||
-  clientY > Math.ceil(bottom);
+  // so we round DOMRect boundaries to make DOMRect slightly bigger.
+  // Also exceed the DOMRect by 1 pixel to fix Chromium reporting MouseEvent's
+  // `clientX` and `clientY` by the whole integer away from the DOMRect.
+  // see https://github.com/mohsinulhaq/react-popper-tooltip/issues/118#issuecomment-782698921
+  return (
+    clientX < Math.floor(left) - 1 ||
+    clientX > Math.ceil(right) + 1 ||
+    clientY < Math.floor(top) - 1 ||
+    clientY > Math.ceil(bottom) + 1
+  );
+};
 
 /**
  * Checks if mouseevent is triggered outside triggerRef and tooltipRef.

--- a/tests/usePopperTooltip.spec.tsx
+++ b/tests/usePopperTooltip.spec.tsx
@@ -48,8 +48,8 @@ describe('trigger option', () => {
 
     // tooltip hidden on hover out
     userEvent.unhover(screen.getByText(TriggerText), {
-      clientX: 1,
-      clientY: 1,
+      clientX: 100,
+      clientY: 100,
     });
     await waitFor(() => {
       expect(screen.queryByText(TooltipText)).not.toBeInTheDocument();
@@ -201,8 +201,8 @@ test('delayHide option removes tooltip after specified delay', async () => {
   expect(await screen.findByText(TooltipText)).toBeInTheDocument();
 
   userEvent.unhover(screen.getByText(TriggerText), {
-    clientX: 1,
-    clientY: 1,
+    clientX: 100,
+    clientY: 100,
   });
   // Still present after 2000ms
   act(() => {
@@ -242,8 +242,8 @@ test('onVisibleChange option called when state changes', async () => {
 
   // Now visible, change visible to false when unhover
   userEvent.unhover(screen.getByText(TriggerText), {
-    clientX: 1,
-    clientY: 1,
+    clientX: 100,
+    clientY: 100,
   });
   await waitFor(() => {
     expect(screen.queryByText(TooltipText)).not.toBeInTheDocument();

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -65,10 +65,10 @@ describe('isMouseOutside', () => {
     const trigger = element(100, 100, 40, 40);
     const tooltipAbove = element(100, 50, 40, 40);
     expect(isMouseOutside(mouseEvent(0, 0), trigger, tooltipAbove)).toBe(true);
-    expect(isMouseOutside(mouseEvent(99, 70), trigger, tooltipAbove)).toBe(
+    expect(isMouseOutside(mouseEvent(98, 70), trigger, tooltipAbove)).toBe(
       true
     );
-    expect(isMouseOutside(mouseEvent(120, 49), trigger, tooltipAbove)).toBe(
+    expect(isMouseOutside(mouseEvent(120, 48), trigger, tooltipAbove)).toBe(
       true
     );
   });


### PR DESCRIPTION
Use `clientX,Y` from `MouseEvent` instead `pageX,Y`

fixes #118