### PR TITLE
Hide tooltip if reference is hidden or tooltip is clipped

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -18,6 +18,11 @@
   pointer-events: none;
 }
 
+.tooltip-container[data-popper-escaped='true'],
+.tooltip-container[data-popper-reference-hidden='true'] {
+  visibility: hidden;
+}
+
 .tooltip-arrow {
   height: 1rem;
   position: absolute;


### PR DESCRIPTION
This PR addresses another behavior in #122 when the tooltip remains visible after the scroll outside of the scroll container.