### PR TITLE
Add ability to trigger tooltips via keyboard

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as PopperJS from '@popperjs/core';
 
-export type TriggerType = 'click' | 'right-click' | 'hover' | 'focus';
+export type TriggerType = 'click' | 'right-click' | 'hover' | 'focus' | 'enter';
 
 export type Config = {
   /**

--- a/src/usePopperTooltip.ts
+++ b/src/usePopperTooltip.ts
@@ -178,6 +178,20 @@ export function usePopperTooltip(
     };
   }, [triggerRef, isTriggeredBy, showTooltip, hideTooltip]);
 
+  // Trigger: enter
+  React.useEffect(() => {
+    if (triggerRef == null || !isTriggeredBy('enter')) return;
+
+    triggerRef.addEventListener('keydown', (e) => {
+      if (e.code === 'Enter') toggleTooltip();
+    });
+    return () => {
+      triggerRef.addEventListener('keydown', (e) => {
+        if (e.code === 'Enter') toggleTooltip();
+      });
+    };
+  }, [triggerRef, isTriggeredBy, toggleTooltip]);
+
   // Trigger: hover on trigger
   React.useEffect(() => {
     if (triggerRef == null || !isTriggeredBy('hover')) return;

--- a/stories/basic.stories.tsx
+++ b/stories/basic.stories.tsx
@@ -81,7 +81,7 @@ Example.argTypes = {
   trigger: {
     control: {
       type: 'select',
-      options: ['hover', 'click', 'right-click', 'focus', null],
+      options: ['hover', 'click', 'right-click', 'focus', 'enter', null],
     },
   },
 };

--- a/tests/usePopperTooltip.spec.tsx
+++ b/tests/usePopperTooltip.spec.tsx
@@ -128,7 +128,7 @@ describe('trigger option', () => {
   });
 
   test('trigger array', async () => {
-    render(<Tooltip options={{ trigger: ['click', 'hover'] }} />);
+    render(<Tooltip options={{ trigger: ['click', 'hover', 'enter'] }} />);
 
     // tooltip not visible initially
     expect(screen.queryByText(TooltipText)).not.toBeInTheDocument();
@@ -142,6 +142,13 @@ describe('trigger option', () => {
     await waitFor(() => {
       expect(screen.queryByText(TooltipText)).not.toBeInTheDocument();
     });
+
+    //tooltip shown on enter
+    fireEvent.keyDown(screen.getByText(TriggerText), {
+      key: 'Enter',
+      code: 'Enter',
+    });
+    expect(await screen.findByText(TooltipText)).toBeInTheDocument();
   });
 
   test('null trigger', async () => {

--- a/tests/usePopperTooltip.spec.tsx
+++ b/tests/usePopperTooltip.spec.tsx
@@ -104,6 +104,29 @@ describe('trigger option', () => {
     });
   });
 
+  test('enter trigger', async () => {
+    render(<Tooltip options={{ trigger: 'enter' }} />);
+
+    // tooltip not visible initially
+    expect(screen.queryByText(TooltipText)).not.toBeInTheDocument();
+
+    // tooltip shown on enter
+    fireEvent.keyDown(screen.getByText(TriggerText), {
+      key: 'Enter',
+      code: 'Enter',
+    });
+    expect(await screen.findByText(TooltipText)).toBeInTheDocument();
+
+    // tooltip hidden on enter again
+    fireEvent.keyDown(screen.getByText(TriggerText), {
+      key: 'Enter',
+      code: 'Enter',
+    });
+    await waitFor(() => {
+      expect(screen.queryByText(TooltipText)).not.toBeInTheDocument();
+    });
+  });
+
   test('trigger array', async () => {
     render(<Tooltip options={{ trigger: ['click', 'hover'] }} />);
 


### PR DESCRIPTION
## Issue
Currently, it is impossible to trigger a tooltip via keyboard inputs, which goes against [WCAG guidelines](https://www.w3.org/TR/wai-aria-practices/#tooltip). All tooltips should be navigable, and triggered, by keyboard. 

## Solution
This PR adds the ability to strike the 'ENTER' key while the `triggerRef` element has keyboard focus and trigger the tooltip's toggle. To reproduce, start `yarn storybook` and select `enter` as the trigger. Use your keyboard to navigate to the trigger button and hit ENTER.

## Screenshots
![enter](https://user-images.githubusercontent.com/17681528/124332987-90ed2e00-db58-11eb-884c-f86d35a40c51.gif)

## Potential improvements
- an option to use the ESCAPE key to hide any current visible tooltips.