### PR TITLE
Cast 'style' to React.CSSProperties type

### DIFF
--- a/src/usePopperTooltip.ts
+++ b/src/usePopperTooltip.ts
@@ -253,7 +253,7 @@ export function usePopperTooltip(
       style: {
         ...args.style,
         ...styles.popper,
-      },
+      } as React.CSSProperties,
       ...attributes.popper,
       'data-popper-interactive': finalConfig.interactive,
     };
@@ -267,7 +267,7 @@ export function usePopperTooltip(
       style: {
         ...args.style,
         ...styles.arrow,
-      },
+      } as React.CSSProperties,
       'data-popper-arrow': true,
     };
   };


### PR DESCRIPTION
Casting style field to be `React.CSSProperties`, to prevent larger TS output in `usePopperTooltip.d.ts`.

I believe this should fix https://github.com/mohsinulhaq/react-popper-tooltip/issues/140 and https://github.com/mohsinulhaq/react-popper-tooltip/issues/144

## Before
```typescript
import * as React from 'react';
import { Config, PopperOptions, PropsGetterArgs } from './types';
export declare function usePopperTooltip(config?: Config, popperOptions?: PopperOptions): {
    state: import("@popperjs/core").State | null;
    update: (() => Promise<Partial<import("@popperjs/core").State>>) | null;
    forceUpdate: (() => void) | null;
    getArrowProps: (args?: PropsGetterArgs) => {
        style: {
            accentColor?: import("csstype").Property.AccentColor | undefined;
            alignContent?: import("csstype").Property.AlignContent | undefined;
            alignItems?: import("csstype").Property.AlignItems | undefined;
            alignSelf?: import("csstype").Property.AlignSelf | undefined;
            alignTracks?: import("csstype").Property.AlignTracks | undefined;
            ... // There are hundreds more of these
        };
        'data-popper-arrow': boolean;
    };
    getTooltipProps: (args?: PropsGetterArgs) => {
        'data-popper-interactive': boolean | undefined;
        style: {
            accentColor?: import("csstype").Property.AccentColor | undefined;
            alignContent?: import("csstype").Property.AlignContent | undefined;
            alignItems?: import("csstype").Property.AlignItems | undefined;
            alignSelf?: import("csstype").Property.AlignSelf | undefined;
            alignTracks?: import("csstype").Property.AlignTracks | undefined;
            ... // There are hundreds more of these
        };
    };
    setTooltipRef: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
    setTriggerRef: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
    tooltipRef: HTMLElement | null;
    triggerRef: HTMLElement | null;
    visible: boolean;
};

```

## After
```typescript
import * as React from 'react';
import { Config, PopperOptions, PropsGetterArgs } from './types';
export declare function usePopperTooltip(config?: Config, popperOptions?: PopperOptions): {
    state: import("@popperjs/core").State | null;
    update: (() => Promise<Partial<import("@popperjs/core").State>>) | null;
    forceUpdate: (() => void) | null;
    getArrowProps: (args?: PropsGetterArgs) => {
        style: React.CSSProperties;
        'data-popper-arrow': boolean;
    };
    getTooltipProps: (args?: PropsGetterArgs) => {
        'data-popper-interactive': boolean | undefined;
        style: React.CSSProperties;
    };
    setTooltipRef: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
    setTriggerRef: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
    tooltipRef: HTMLElement | null;
    triggerRef: HTMLElement | null;
    visible: boolean;
};
```