### PR TITLE
add missing hover check to interactive effect

### DIFF
--- a/src/usePopperTooltip.ts
+++ b/src/usePopperTooltip.ts
@@ -202,7 +202,12 @@ export function usePopperTooltip(
 
   // Trigger: hover on tooltip, keep it open if hovered
   React.useEffect(() => {
-    if (tooltipRef == null || !getLatest().finalConfig.interactive) return;
+    if (
+      tooltipRef == null ||
+      !isTriggeredBy('hover') ||
+      !getLatest().finalConfig.interactive
+    )
+      return;
 
     tooltipRef.addEventListener('mouseenter', showTooltip);
     tooltipRef.addEventListener('mouseleave', hideTooltip);
@@ -210,7 +215,7 @@ export function usePopperTooltip(
       tooltipRef.removeEventListener('mouseenter', showTooltip);
       tooltipRef.removeEventListener('mouseleave', hideTooltip);
     };
-  }, [tooltipRef, showTooltip, hideTooltip, getLatest]);
+  }, [tooltipRef, isTriggeredBy, showTooltip, hideTooltip, getLatest]);
 
   // Handle closing tooltip if trigger hidden
   const isReferenceHidden =


### PR DESCRIPTION
Previously, setting 'interactive' to true would inadvertently add mouseenter / mouseleave listeners to the tooltip. This makes interactive tooltips with other triggers behave as though they have the 'hover' trigger.

After this change, tooltips that are not triggered by 'hover' will no longer receive register these listeners.

Example codesandbox of the observed unexpected behavior:
https://codesandbox.io/s/optimistic-parm-qpsrlc

Here's the same example after the proposed change (codesandbox doesn't like custom npm registries 😢 ):
https://sarah.engineer/react-popper-tooltip-demo/